### PR TITLE
Randomization of Et and Modification of Reset Method Following Election Conflicts

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -705,7 +705,7 @@ func (r *raft) sendHeartbeat(to uint64, ctx []byte) {
 	seqID := r.heartbeatStates[to].sequenceId
 	seqIdInt64 := int64(seqID)
 
-	r.logger.Debugf("Sending heartbeat to %x at term %d with RTT %v", to, r.Term, rtt)
+	r.logger.Infof("Sending heartbeat to %x at term %d with RTT %v", to, r.Term, rtt)
 
 	timestamp := time.Now().UnixNano()
 	rttInt64 := int64(rtt)
@@ -1584,13 +1584,13 @@ func stepLeader(r *raft, m pb.Message) error {
 		if m.HeartbeatInterval != nil {
 			heartbeatInterval := *m.HeartbeatInterval
 			if heartbeatInterval != -1 {
-				r.logger.Debugf("Received heartbeat response from %d with interval %d", m.From, heartbeatInterval)
+				r.logger.Infof("Received heartbeat response from %d with interval %d", m.From, heartbeatInterval)
 		
 				if _, exists := r.heartbeatStates[m.From]; exists {
 					r.heartbeatStates[m.From].timeout = int(heartbeatInterval)
 				}
 			} else {
-				r.logger.Debugf("Received heartbeat response from %d.", m.From)
+				r.logger.Infof("Received heartbeat response from %d.", m.From)
 			}
 		}
 

--- a/raft.go
+++ b/raft.go
@@ -929,10 +929,10 @@ func (r *raft) becomeCandidate() {
 		panic("invalid transition [leader -> candidate]")
 	}
 	r.step = stepCandidate
-	r.state = StateCandidate
 	r.reset(r.Term + 1)
 	r.tick = r.tickElection
 	r.Vote = r.id
+	r.state = StateCandidate
 
 	r.logger.Infof("Current state: %v, LastCampaignTimeTaken: %v", r.state, r.lastCampaignTimeTaken)
 	baseTimeoutMs := int(r.lastCampaignTimeTaken / time.Millisecond)

--- a/raft.go
+++ b/raft.go
@@ -1857,6 +1857,7 @@ func (r *raft) handleHeartbeat(m pb.Message) {
             r.randomizedElectionTimeout = int(newMean.Milliseconds() + int64(r.electionSafetyFactor)*newStdDev.Milliseconds())
         }
     }
+	r.logger.Infof("Current randomizedElectionTimeout: %d", r.randomizedElectionTimeout)
 
     if m.SequenceId != nil && m.SendTime != nil {
         sequenceId := uint64(*m.SequenceId)

--- a/raft.go
+++ b/raft.go
@@ -705,7 +705,7 @@ func (r *raft) sendHeartbeat(to uint64, ctx []byte) {
 	seqID := r.heartbeatStates[to].sequenceId
 	seqIdInt64 := int64(seqID)
 
-	r.logger.Infof("Sending heartbeat to %x at term %d with RTT %v", to, r.Term, rtt)
+    r.logger.Infof("Sending heartbeat to %x at term %d with RTT %v, sequence ID %d", to, r.Term, rtt, seqID)
 
 	timestamp := time.Now().UnixNano()
 	rttInt64 := int64(rtt)

--- a/raft.go
+++ b/raft.go
@@ -668,7 +668,7 @@ func (r *raft) maybeSendAppend(to uint64, sendIfEmpty bool) bool {
 		r.logger.Debugf("%x paused sending replication messages to %x [%s]", r.id, to, pr)
 
 		r.send(pb.Message{To: to, Type: pb.MsgSnap, Snapshot: &snapshot})
-		r.resetHeartbeatElapsed(to)
+		//r.resetHeartbeatElapsed(to)
 		return true
 	}
 
@@ -685,7 +685,7 @@ func (r *raft) maybeSendAppend(to uint64, sendIfEmpty bool) bool {
 		Entries: ents,
 		Commit:  r.raftLog.committed,
 	})
-	r.resetHeartbeatElapsed(to)
+	//r.resetHeartbeatElapsed(to)
 	return true
 }
 
@@ -2258,13 +2258,13 @@ func (r *raft) calculateHeartbeatInterval(packetLossRate float64) int64 {
 	return heartbeatInterval
 }
 
-func (r *raft) resetHeartbeatElapsed(id uint64) {
-	if hbState, ok := r.heartbeatStates[id]; ok {
-		hbState.elapsed = 0
-		r.heartbeatStates[id] = hbState
-	} else {
-	}
-}
+//func (r *raft) resetHeartbeatElapsed(id uint64) {
+//	if hbState, ok := r.heartbeatStates[id]; ok {
+//		hbState.elapsed = 0
+//		r.heartbeatStates[id] = hbState
+//	} else {
+//	}
+//}
 
 func (r *raft) printFollowerMetrics(fm *followerMetrics) {
 	r.logger.Debugf("Follower Metrics:")

--- a/raft.go
+++ b/raft.go
@@ -1843,13 +1843,13 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 }
 
 func (r *raft) handleHeartbeat(m pb.Message) {
-    r.logger.Debugf("Received heartbeat from %d.", m.From)
+    r.logger.Infof("Received heartbeat from %d.", m.From)
 
     r.raftLog.commitTo(m.Commit)
     var heartbeatInterval int64
 
     if m.Rtt != nil {
-        r.logger.Debugf("Received RTT from %d: %d ns.", m.From, *m.Rtt)
+        r.logger.Infof("Received RTT from %d: %d ns.", m.From, *m.Rtt)
         r.followerMetrics.addRTT(time.Duration(*m.Rtt))
         newMean := r.followerMetrics.getMean()
         newStdDev := r.followerMetrics.getStdDev()
@@ -1865,7 +1865,7 @@ func (r *raft) handleHeartbeat(m pb.Message) {
 
         if r.followerMetrics.isSequenceIdQueueGreaterThanMin() {
             packetLossRate := r.followerMetrics.calculatePacketLossRate()
-            r.logger.Debugf("Calculated packet loss rate after receiving heartbeat from %d: %f.", m.From, packetLossRate)
+            r.logger.Infof("Calculated packet loss rate after receiving heartbeat from %d: %f.", m.From, packetLossRate)
             heartbeatInterval = r.calculateHeartbeatInterval(packetLossRate)
         } else {
             heartbeatInterval = -1
@@ -1875,9 +1875,9 @@ func (r *raft) handleHeartbeat(m pb.Message) {
     r.printFollowerMetrics(r.followerMetrics)
 
     if heartbeatInterval != -1 {
-        r.logger.Debugf("Replying to %d with heartbeat response; interval set to %d.", m.From, heartbeatInterval)
+        r.logger.Infof("Replying to %d with heartbeat response; interval set to %d.", m.From, heartbeatInterval)
     } else {
-        r.logger.Debugf("Replying to %d with heartbeat response; interval not set due to insufficient data.", m.From)
+        r.logger.Infof("Replying to %d with heartbeat response; interval not set due to insufficient data.", m.From)
     }
 
     r.send(pb.Message{
@@ -2105,8 +2105,6 @@ func (r *raft) pastElectionTimeout() bool {
 
 func (r *raft) resetRandomizedElectionTimeout() {
 	r.randomizedElectionTimeout = r.electionTimeout + globalRand.Intn(r.electionTimeout)
-	r.logger.Debugf("resetRandomizedElectionTimeout: electionTimeout=%d, randomizedElectionTimeout=%d",
-        r.electionTimeout, r.randomizedElectionTimeout)
 }
 
 func (r *raft) sendTimeoutNow(to uint64) {
@@ -2241,16 +2239,16 @@ func (r *raft) resetHeartbeatElapsed(id uint64) {
 }
 
 func (r *raft) printFollowerMetrics(fm *followerMetrics) {
-    r.logger.Debugf("Follower Metrics:")
-    r.logger.Debugf("RTT Queue: %v", fm.rttQueue)
-    r.logger.Debugf("Deviation Squares: %v", fm.deviationSqs)
-    r.logger.Debugf("Sum: %v", fm.sum)
-    r.logger.Debugf("Mean: %v", fm.mean)
-    r.logger.Debugf("M2: %v", fm.m2)
-    r.logger.Debugf("Count: %d", fm.count)
-    r.logger.Debugf("Sequence ID Queue: %v", sequenceIdQueueToString(fm.sequenceIdQueue))
-    r.logger.Debugf("Max Queue Size: %d", fm.maxQueueSize)
-    r.logger.Debugf("Min Queue Size: %d", fm.minQueueSize)
+    r.logger.Infof("Follower Metrics:")
+    r.logger.Infof("RTT Queue: %v", fm.rttQueue)
+    r.logger.Infof("Deviation Squares: %v", fm.deviationSqs)
+    r.logger.Infof("Sum: %v", fm.sum)
+    r.logger.Infof("Mean: %v", fm.mean)
+    r.logger.Infof("M2: %v", fm.m2)
+    r.logger.Infof("Count: %d", fm.count)
+    r.logger.Infof("Sequence ID Queue: %v", sequenceIdQueueToString(fm.sequenceIdQueue))
+    r.logger.Infof("Max Queue Size: %d", fm.maxQueueSize)
+    r.logger.Infof("Min Queue Size: %d", fm.minQueueSize)
 }
 
 func sequenceIdQueueToString(queue []sequenceIdInfo) string {

--- a/raft.go
+++ b/raft.go
@@ -2349,15 +2349,20 @@ func (fm *followerMetrics) addSequenceIdInfo(id uint64, timestamp time.Time) {
     }
 
     inserted := false
-    for i := len(fm.sequenceIdQueue) - 1; i >= 0; i-- {
-        if info.timestamp.After(fm.sequenceIdQueue[i].timestamp) {
-            fm.sequenceIdQueue = append(fm.sequenceIdQueue[:i+1], append([]sequenceIdInfo{info}, fm.sequenceIdQueue[i+1:]...)...)
+    duplicate := false
+
+    for i, existingInfo := range fm.sequenceIdQueue {
+        if info.timestamp.Equal(existingInfo.timestamp) {
+            duplicate = true
+            break
+        } else if info.timestamp.After(existingInfo.timestamp) {
+            fm.sequenceIdQueue = append(fm.sequenceIdQueue[:i], append([]sequenceIdInfo{info}, fm.sequenceIdQueue[i:]...)...)
             inserted = true
             break
         }
     }
 
-    if !inserted {
+    if !inserted && !duplicate {
         fm.sequenceIdQueue = append([]sequenceIdInfo{info}, fm.sequenceIdQueue...)
     }
 

--- a/raftpb/raft.proto
+++ b/raftpb/raft.proto
@@ -105,7 +105,7 @@ message Message {
 	// to respond and who to respond to when the work associated with a message
 	// is complete. Populated for MsgStorageAppend and MsgStorageApply messages.
 	repeated Message     responses   = 14 [(gogoproto.nullable) = false];
-	// added by @skoya76
+	// The following fields are used for dynamic optimization of election parameters.
 	optional int64 rtt = 15;
 	optional int64 send_time = 16;
 	optional int64 sequence_id = 17;


### PR DESCRIPTION
Previously, the election timeout (Et) was set based on the average and standard deviation of the Round-Trip Time (RTT) between replicas. This approach led to simultaneous election initiations when the RTT was equal across all replicas, resulting in election conflicts.

To address this issue, we have now introduced a randomized factor to the calculation of Et, similar to the default mechanism. The election timeout is now randomly set between 1 to 2 times the calculated value, reducing the likelihood of concurrent elections among replicas.

Furthermore, we have optimized the post-election reset process. Instead of calling resetRandomizedElectionTimeout after an election conflict, the reset now utilizes the maximum RTT measured during the pre-vote phase. This adjustment significantly shortens the recovery time by aligning the election timeout more closely with actual network conditions.

